### PR TITLE
Add alter_toy to frontend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import "./App.css";
 export default function App() {
   const [toys, setToys] = useState<FeVCToy[]>([]);
 
-  async function getToys() {
+  async function refetchToys() {
     await invoke<null | { [key: number]: FeVCToy }>(GET_TOYS).then((response) =>
       setToys(response ? Object.values(response) : [])
     );
@@ -24,12 +24,14 @@ export default function App() {
         <div className="toys-container">
           <h1 className="grad-text">Connected toys</h1>
           {toys.length > 0 ? (
-            toys.map((toy) => <Toy toy={toy} key={toy.toy_id} />)
+            toys.map((toy) => (
+              <Toy key={toy.toy_id} toy={toy} refetchToys={refetchToys} />
+            ))
           ) : (
             <div>None</div>
           )}
         </div>
-        <Footer getToys={getToys} />
+        <Footer refetchToys={refetchToys} />
       </div>
     </div>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,17 @@
 import { invoke } from "@tauri-apps/api";
 import { useEffect, useState } from "react";
 
-import { DISABLE, ENABLE, START_SCAN, STOP_SCAN } from "../data/constants";
+import {
+  DISABLE,
+  ENABLE,
+  SCAN_CHECK_INTERVAL,
+  SCAN_LENGTH,
+  START_SCAN,
+  STOP_SCAN,
+} from "../data/constants";
 import SettingsModal from "./SettingsModal";
 
-export default function (props: { getToys: () => void }) {
+export default function ({ refetchToys }: { refetchToys: () => void }) {
   const [isEnabled, setIsEnabled] = useState(false);
   const [isScanning, setIsScanning] = useState(false);
   const [settingsIsOpen, setSettingsIsOpen] = useState(false);
@@ -28,7 +35,7 @@ export default function (props: { getToys: () => void }) {
         toggleIsScanning();
       }
       await invoke(DISABLE).then(() => setIsEnabled(false));
-      props.getToys(); // Clear toy list after we disable
+      refetchToys(); // Clear toy list after we disable
     } else {
       await invoke(ENABLE).then(() => setIsEnabled(true));
     }
@@ -36,15 +43,15 @@ export default function (props: { getToys: () => void }) {
 
   useEffect(() => {
     if (isScanning) {
-      // While scanning, check backend every second
+      // While scanning, check backend every x ms
       const interval = setInterval(() => {
-        props.getToys();
-      }, 1000);
+        refetchToys();
+      }, SCAN_CHECK_INTERVAL);
 
-      // Turn off scan after 10 seconds
+      // Turn off scan after y ms
       const timeout = setTimeout(() => {
         toggleIsScanning();
-      }, 10000);
+      }, SCAN_LENGTH);
 
       return () => {
         clearTimeout(timeout);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -25,7 +25,7 @@ export default function (props: settingsModalProps) {
     getConfig()
       .then((r) => setConfig(r))
       .catch(() => setConfig(null));
-  });
+  }, []);
 
   async function updateConfig() {
     if (oscBind.current?.value == null || config == null) {

--- a/src/components/Toy.tsx
+++ b/src/components/Toy.tsx
@@ -5,7 +5,13 @@ import { percent } from "../utils";
 import NameBadge from "./NameBadge";
 import ToyFeatureForm from "./ToyFeatureForm";
 
-export default function ({ toy }: { toy: FeVCToy }) {
+export default function ({
+  toy,
+  refetchToys,
+}: {
+  toy: FeVCToy;
+  refetchToys: () => void;
+}) {
   return (
     <div className="toy-container">
       <div className="toy">
@@ -30,7 +36,11 @@ export default function ({ toy }: { toy: FeVCToy }) {
               >{`${feature.feature_type} ${feature.feature_index}`}</Badge>
             </Accordion.Header>
             <Accordion.Body>
-              <ToyFeatureForm {...feature} />
+              <ToyFeatureForm
+                toyId={toy.toy_id}
+                feature={feature}
+                refetchToys={refetchToys}
+              />
             </Accordion.Body>
           </Accordion.Item>
         ))}

--- a/src/components/ToyFeatureForm.tsx
+++ b/src/components/ToyFeatureForm.tsx
@@ -1,20 +1,42 @@
-import { useState } from "react";
+import { invoke } from "@tauri-apps/api";
+import { useEffect, useState } from "react";
 import Form from "react-bootstrap/Form";
 import { FeVCToyFeature } from "../../src-tauri/bindings/FeVCToyFeature";
+import { ALTER_TOY, ALTER_TOY_DEBOUNCE } from "../data/constants";
 import { round0 } from "../utils";
 import "./ToyFeatureForm.css";
 
-export default function (props: FeVCToyFeature) {
-  const [state, setState] = useState<FeVCToyFeature>(props);
+type ToyFeatureFormProps = {
+  toyId: number;
+  feature: FeVCToyFeature;
+  refetchToys: () => void;
+};
+
+export default function ({ toyId, feature, refetchToys }: ToyFeatureFormProps) {
+  const [modifiedFeature, setModifiedFeature] =
+    useState<FeVCToyFeature>(feature);
+
+  useEffect(() => {
+    async function setFeature() {
+      await invoke(ALTER_TOY, { toyId: toyId, toyFeature: modifiedFeature });
+    }
+    if (modifiedFeature != feature) {
+      const t = setTimeout(() => {
+        setFeature();
+        refetchToys();
+      }, ALTER_TOY_DEBOUNCE);
+      return () => clearTimeout(t);
+    }
+  }, [modifiedFeature]);
 
   return (
     <>
       <div className="item">
         <Form.Label>Enabled</Form.Label>
         <Form.Check
-          checked={state.feature_enabled}
+          checked={modifiedFeature.feature_enabled}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return { ...s, feature_enabled: e.target.checked };
             })
           }
@@ -24,9 +46,9 @@ export default function (props: FeVCToyFeature) {
         <Form.Label>OSC Parameter</Form.Label>
         <div></div>
         <Form.Control
-          value={state.osc_parameter}
+          value={modifiedFeature.osc_parameter}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return { ...s, osc_parameter: e.target.value };
             })
           }
@@ -35,32 +57,32 @@ export default function (props: FeVCToyFeature) {
       <div className="item">
         <Form.Label>Smoothing</Form.Label>
         <Form.Check
-          checked={state.smooth_enabled}
+          checked={modifiedFeature.smooth_enabled}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return { ...s, smooth_enabled: e.target.checked };
             })
           }
         />
         <Form.Range
-          disabled={!state.smooth_enabled}
+          disabled={!modifiedFeature.smooth_enabled}
           min={1}
           max={20}
           step={1}
-          value={state.feature_levels.smooth_rate}
+          value={modifiedFeature.feature_levels.smooth_rate}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return {
                 ...s,
                 feature_levels: {
-                  ...state.feature_levels,
+                  ...modifiedFeature.feature_levels,
                   smooth_rate: Number(e.target.value),
                 },
               };
             })
           }
         />
-        {state.feature_levels.smooth_rate}
+        {modifiedFeature.feature_levels.smooth_rate}
       </div>
       <div className="item">
         <Form.Label>Idle</Form.Label>
@@ -69,20 +91,20 @@ export default function (props: FeVCToyFeature) {
           min={0}
           max={1}
           step={0.01}
-          value={state.feature_levels.idle_level}
+          value={modifiedFeature.feature_levels.idle_level}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return {
                 ...s,
                 feature_levels: {
-                  ...state.feature_levels,
+                  ...modifiedFeature.feature_levels,
                   idle_level: Number(e.target.value),
                 },
               };
             })
           }
         />
-        {round0.format(state.feature_levels.idle_level * 100)}
+        {round0.format(modifiedFeature.feature_levels.idle_level * 100)}
       </div>
       <div className="item">
         <Form.Label>Minimum</Form.Label>
@@ -91,20 +113,20 @@ export default function (props: FeVCToyFeature) {
           min={0}
           max={1}
           step={0.01}
-          value={state.feature_levels.minimum_level}
+          value={modifiedFeature.feature_levels.minimum_level}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return {
                 ...s,
                 feature_levels: {
-                  ...state.feature_levels,
+                  ...modifiedFeature.feature_levels,
                   minimum_level: Number(e.target.value),
                 },
               };
             })
           }
         />
-        {round0.format(state.feature_levels.minimum_level * 100)}
+        {round0.format(modifiedFeature.feature_levels.minimum_level * 100)}
       </div>
       <div className="item">
         <Form.Label>Maximum</Form.Label>
@@ -113,20 +135,20 @@ export default function (props: FeVCToyFeature) {
           min={0}
           max={1}
           step={0.01}
-          value={state.feature_levels.maximum_level}
+          value={modifiedFeature.feature_levels.maximum_level}
           onChange={(e) =>
-            setState((s) => {
+            setModifiedFeature((s) => {
               return {
                 ...s,
                 feature_levels: {
-                  ...state.feature_levels,
+                  ...modifiedFeature.feature_levels,
                   maximum_level: Number(e.target.value),
                 },
               };
             })
           }
         />
-        {round0.format(state.feature_levels.maximum_level * 100)}
+        {round0.format(modifiedFeature.feature_levels.maximum_level * 100)}
       </div>
     </>
   );

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,4 +1,5 @@
 export const GET_TOYS = "get_toys";
+export const ALTER_TOY = "alter_toy";
 export const START_SCAN = "vibecheck_start_bt_scan";
 export const STOP_SCAN = "vibecheck_stop_bt_scan";
 export const ENABLE = "vibecheck_enable";
@@ -6,3 +7,7 @@ export const DISABLE = "vibecheck_disable";
 export const VERSION = "vibecheck_version";
 export const GET_CONFIG = "get_vibecheck_config";
 export const SET_CONFIG = "set_vibecheck_config";
+
+export const SCAN_LENGTH = 10000;
+export const SCAN_CHECK_INTERVAL = 1000;
+export const ALTER_TOY_DEBOUNCE = 100;


### PR DESCRIPTION
All the main f/e stuff should be working now. I added a 100ms debounce so I don't spam Invoke. Not sure how necessary it is or how low it should be.

The logging says "Sent UpdateToy to x toys" but since there's a dummy receiver x is always len(toys)+1.
``` rust
ToyUpdate::AlterToy(toy) => {
    match toy_bcst_tx.send(ToySig::UpdateToy(
        ToyUpdate::AlterToy(toy.clone()),
    )) {
        Ok(receivers) => info!("Sent UpdateToy to {} toys", receivers),
        Err(e) => logerr!("Failed to send UpdateToy: {}", e),
    }
    toys.insert(toy.toy_id, toy);
}
```
I think the line above should change to:
``` rust
info!("Sent UpdateToy to {} toys", receivers-1)
```
or
``` rust
info!("Sent UpdateToy to {} receivers", receivers)
```